### PR TITLE
Bump CMake version to avoid CMP0048 warning

### DIFF
--- a/industrial_core/CMakeLists.txt
+++ b/industrial_core/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(industrial_core)
 find_package(catkin REQUIRED)
 catkin_metapackage()

--- a/industrial_deprecated/CMakeLists.txt
+++ b/industrial_deprecated/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(industrial_deprecated)
 

--- a/industrial_msgs/CMakeLists.txt
+++ b/industrial_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(industrial_msgs)
 

--- a/industrial_robot_client/CMakeLists.txt
+++ b/industrial_robot_client/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(industrial_robot_client)
 

--- a/industrial_robot_simulator/CMakeLists.txt
+++ b/industrial_robot_simulator/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(industrial_robot_simulator)
 

--- a/industrial_trajectory_filters/CMakeLists.txt
+++ b/industrial_trajectory_filters/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(industrial_trajectory_filters)
 

--- a/industrial_utils/CMakeLists.txt
+++ b/industrial_utils/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(industrial_utils)
 

--- a/simple_message/CMakeLists.txt
+++ b/simple_message/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(simple_message)
 


### PR DESCRIPTION
just some minor addition as recommended in the [Noetic Migration Guide](http://wiki.ros.org/noetic/Migration#Increase_required_CMake_version_to_avoid_author_warning)